### PR TITLE
Update plugin BOM 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.375.x</artifactId>
-                <version>2025.v816d28f1e04f</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2143.ve4c3c9ec790a</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## What

What does the PR do?
This PR is doing a version upgrade of BOM.

## Why
Why this PR is needed?
Related issue: https://github.com/jenkinsci/cdevents-plugin/issues/5

## How
All test cases finished successfully and SputBugs could not find any bug. 
App can build successfully.

### Changes details

- Old Dependency of BOM
`
                <artifactId>bom-2.375.x</artifactId>
                <version>2025.v816d28f1e04f</version>
`

- New Dependency of BOM
`
                <artifactId>bom-2.401.x</artifactId>
                <version>2143.ve4c3c9ec790a</version>`

##  Important
cdevents-plugin is using Jenkins 2.375.4 version. 
aws-java-sdk dependency is already latest for this Jenkins version. I didn't change anything about aws-java-sdk.
Also compatible latest version of bom is my updated version. There are newer versions of BOM but these aren't compatible with Jenkins 2.375.4. 


## Missed anything?

- [ x ] Explained the purpose of this PR.
- [ x ] Self reviewed the PR.
- [ x ] Added or updated test cases.
- [ x ] Informed of breaking changes, testing and migrations (if applicable).
- [ x ] Updated documentation (if applicable).
- [ x ] Attached screenshots (if applicable).


![image](https://github.com/jenkinsci/cdevents-plugin/assets/38990648/7c450855-18e2-4c8b-b81a-0b67ce960462)

