### PR TITLE
Use CDEvents SDK v0.1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Early adopters and testers are welcome to try out the plugin and provide feedbac
    ```shell
    mvn clean hpi:run
    ```
+   
+You may need to add `-Dhost=0.0.0.0` to the command if you are running Jenkins in a container or virtual machine.
 
 3. To access your local instance, open a browser to http://localhost:8080/jenkins
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.61</version>
+        <version>4.78</version>
         <relativePath/>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -36,12 +36,12 @@
         <!-- revision: Maps Jenkins plugin release to the cdevents SDK version in use. See VERSIONING.MD -->
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <cdevents.version>v0.1.0-draft6</cdevents.version>
+        <cdevents.version>0.1.2</cdevents.version>
         <gitHubRepo>jenkinsci/cdevents-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or
         newer to run. -->
-        <jenkins.version>2.375.4</jenkins.version>
+        <jenkins.version>2.401.3</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
     </properties>
@@ -51,7 +51,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.401.x</artifactId>
-                <version>2143.ve4c3c9ec790a</version>
+                <version>2745.vc7b_fe4c876fa_</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -81,12 +81,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.12.447-382.vda_68e2007233</version>
+            <version>1.12.633-430.vf9a_e567a_244f</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
-            <groupId>dev.cdevents.sdk-java</groupId>
+            <groupId>dev.cdevents</groupId>
             <artifactId>cdevents-sdk-java</artifactId>
             <version>${cdevents.version}</version>
             <exclusions>

--- a/src/main/java/io/jenkins/plugins/cdevents/BuildCDEvent.java
+++ b/src/main/java/io/jenkins/plugins/cdevents/BuildCDEvent.java
@@ -7,9 +7,9 @@ package io.jenkins.plugins.cdevents;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.cdevents.CDEventTypes;
+import dev.cdevents.CDEvents;
 import dev.cdevents.constants.CDEventConstants;
-import dev.cdevents.models.PipelineRun;
+import dev.cdevents.events.*;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -43,19 +43,31 @@ public class BuildCDEvent {
         return convertedJson;
     }
 
-    public static CloudEvent buildPipelineRunStartedModel(Run run, TaskListener listener)
-            throws IOException, InterruptedException {
+    public static CloudEvent buildPipelineRunStartedModel(Run run,
+                                                          TaskListener listener) throws IOException,
+            InterruptedException {
         String pipelineFullName = run.getParent().getFullDisplayName();
         Object pipelineData = ModelBuilder.buildJobModel(run.getParent(), run, listener);
         LOGGER.log(Level.INFO, "Building PipelineRunStarted model for " + pipelineFullName);
-        return CDEventTypes.createPipelineRunStartedEvent(
-                CDEventConstants.CDEventTypes.PipelineRunStartedEvent.getEventType(), run.getId(),
-                URI.create(run.getParent().getUrl().replaceAll(pipelineFullName, "").replaceAll("//", "/")),
-                pipelineFullName, URI.create(run.getUrl()), convertToJson(pipelineData));
+
+        PipelineRunStartedCDEvent event = new PipelineRunStartedCDEvent();
+        event.setSubjectSource(URI.create(run.getParent()
+                .getUrl()
+                .replaceAll(pipelineFullName, "")
+                .replaceAll("//", "/")));
+        event.setSubjectId(run.getId());
+        event.setSource(URI.create(run.getUrl()));
+        event.setSubjectPipelineName(pipelineFullName);
+        event.setSubjectUrl(URI.create(run.getUrl()));
+        event.setCustomData(convertToJson(pipelineData));
+        event.setCustomDataContentType("application/json");
+
+        return CDEvents.cdEventAsCloudEvent(event);
     }
 
-    public static CloudEvent buildPipelineRunFinishedModel(Run run, TaskListener listener)
-            throws IOException, InterruptedException {
+    public static CloudEvent buildPipelineRunFinishedModel(Run run,
+                                                           TaskListener listener) throws IOException,
+            InterruptedException {
         String pipelineFullName = run.getParent().getFullDisplayName();
         Object pipelineData = ModelBuilder.buildJobModel(run.getParent(), run, listener);
         LOGGER.log(Level.INFO, "Building PipelineRunFinished model for " + pipelineFullName);
@@ -64,31 +76,44 @@ public class BuildCDEvent {
         CDEventConstants.Outcome outcome;
         Result runResult = run.getResult();
         if (runResult != null) {
-            outcome = OutcomeMapper
-                    .mapResultToOutcome(runResult);
-            errors = outcome == CDEventConstants.Outcome.OutcomeSuccess ? ""
-                    : run.getBuildStatusSummary().toString();
+            outcome = OutcomeMapper.mapResultToOutcome(runResult);
+            errors = outcome == CDEventConstants.Outcome.SUCCESS ? "" : run.getBuildStatusSummary().toString();
         } else {
-            outcome = CDEventConstants.Outcome.OutcomeError;
+            outcome = CDEventConstants.Outcome.ERROR;
             errors = "Run was not able to produce a result.";
         }
 
-        return CDEventTypes.createPipelineRunFinishedEvent(
-                CDEventConstants.CDEventTypes.PipelineRunFinishedEvent.getEventType(), run.getId(),
-                URI.create(run.getParent().getUrl().replaceAll(pipelineFullName, "").replaceAll("//", "/")),
-                pipelineFullName, URI.create(run.getUrl()), outcome, errors, convertToJson(pipelineData));
+        PipelineRunFinishedCDEvent event = new PipelineRunFinishedCDEvent();
+
+        event.setSubjectSource(URI.create(run.getParent()
+                .getUrl()
+                .replaceAll(pipelineFullName, "")
+                .replaceAll("//", "/")));
+        event.setSubjectId(run.getId());
+        event.setSource(URI.create(run.getUrl()));
+        event.setSubjectPipelineName(pipelineFullName);
+        event.setCustomData(convertToJson(pipelineData));
+        event.setCustomDataContentType("application/json");
+        event.setSubjectOutcome(outcome);
+        event.setSubjectErrors(errors);
+
+        return CDEvents.cdEventAsCloudEvent(event);
     }
 
     public static CloudEvent buildPipelineRunQueuedModel(Queue.WaitingItem item) {
         String pipelineFullName = item.task.getFullDisplayName();
         Object pipelineData = ModelBuilder.buildQueuedJobModel(item);
         LOGGER.log(Level.INFO, "Building PipelineRunQueued model for " + pipelineFullName);
-        // String eventType, String id, URI source, String pipelineName, URI url, String
-        // pipelineRunData
-        return CDEventTypes.createPipelineRunQueuedEvent(
-                CDEventConstants.CDEventTypes.PipelineRunQueuedEvent.getEventType(), String.valueOf(item.getId()),
-                URI.create(item.task.getUrl()), pipelineFullName, URI.create(item.task.getUrl()),
-                convertToJson(pipelineData));
+
+        PipelineRunQueuedCDEvent event = new PipelineRunQueuedCDEvent();
+        event.setSubjectSource(URI.create(item.task.getUrl()));
+        event.setSubjectId(String.valueOf(item.getId()));
+        event.setSource(URI.create(item.task.getUrl()));
+        event.setSubjectPipelineName(pipelineFullName);
+        event.setCustomData(convertToJson(pipelineData));
+        event.setCustomDataContentType("application/json");
+
+        return CDEvents.cdEventAsCloudEvent(event);
     }
 
     public static CloudEvent buildTaskRunStartedModel(Run run, FlowNode node) {
@@ -96,14 +121,18 @@ public class BuildCDEvent {
         Object taskRunData = ModelBuilder.buildTaskModel(run, node);
         LOGGER.info("Building TaskRunStarted model for " + displayName);
 
-        return CDEventTypes.createTaskRunStartedEvent(
-                CDEventConstants.CDEventTypes.TaskRunStartedEvent.getEventType(),
-                run.getId(),
-                URI.create(run.getParent().getUrl().replaceAll(displayName, "").replaceAll("//", "/")),
-                displayName,
-                new PipelineRun(), // TODO - implement this
-                URI.create(run.getUrl()),
-                convertToJson(taskRunData));
+        TaskRunStartedCDEvent event = new TaskRunStartedCDEvent();
+
+        event.setSubjectSource(URI.create(run.getParent().getUrl().replaceAll(displayName, "").replaceAll("//", "/")));
+        event.setSource(URI.create(run.getUrl()));
+        event.setSubjectId(run.getId());
+        event.setSubjectTaskName(displayName);
+        event.setSubjectPipelineRunId(run.getId());
+        event.setSubjectPipelineRunSource(URI.create(run.getUrl()));
+        event.setCustomData(convertToJson(taskRunData));
+        event.setCustomDataContentType("application/json");
+
+        return CDEvents.cdEventAsCloudEvent(event);
     }
 
     public static CloudEvent buildTaskRunFinishedModel(Run run, FlowNode node) {
@@ -115,24 +144,27 @@ public class BuildCDEvent {
         ErrorAction nodeError = node.getError();
         if (nodeError != null) {
             outcome = OutcomeMapper.mapResultToOutcome(nodeError);
-            errors = outcome == CDEventConstants.Outcome.OutcomeSuccess ? ""
-                    : nodeError.getDisplayName();
+            errors = outcome == CDEventConstants.Outcome.SUCCESS ? "" : nodeError.getDisplayName();
         } else {
-            outcome = CDEventConstants.Outcome.OutcomeError;
+            outcome = CDEventConstants.Outcome.ERROR;
             errors = "Unable to get Display Name of the Node Error.";
         }
 
         LOGGER.info("Building TaskRunFinished model for " + displayName);
 
-        return CDEventTypes.createTaskRunFinishedEvent(
-                CDEventConstants.CDEventTypes.TaskRunFinishedEvent.getEventType(),
-                run.getId(),
-                URI.create(run.getParent().getUrl().replaceAll(displayName, "").replaceAll("//", "/")),
-                displayName,
-                new PipelineRun(), // TODO - implement this
-                URI.create(run.getUrl()),
-                outcome,
-                errors,
-                convertToJson(taskRunData));
+        TaskRunFinishedCDEvent event = new TaskRunFinishedCDEvent();
+        event.setSubjectSource(URI.create(run.getParent().getUrl().replaceAll(displayName, "").replaceAll("//", "/")));
+        event.setSource(URI.create(run.getUrl()));
+        event.setSubjectId(run.getId());
+        event.setSubjectTaskName(displayName);
+        event.setSubjectPipelineRunId(run.getId());
+        event.setSubjectPipelineRunSource(URI.create(run.getUrl()));
+        event.setCustomData(convertToJson(taskRunData));
+        event.setCustomDataContentType("application/json");
+
+        event.setSubjectOutcome(outcome);
+        event.setSubjectErrors(errors);
+
+        return CDEvents.cdEventAsCloudEvent(event);
     }
 }

--- a/src/main/java/io/jenkins/plugins/cdevents/BuildCDEvent.java
+++ b/src/main/java/io/jenkins/plugins/cdevents/BuildCDEvent.java
@@ -38,10 +38,6 @@ public class BuildCDEvent {
         LOGGER.log(Level.INFO, "Building PipelineRunStarted model for " + pipelineFullName);
 
         PipelineRunStartedCDEvent event = new PipelineRunStartedCDEvent();
-        event.setSubjectSource(URI.create(run.getParent()
-                .getUrl()
-                .replaceAll(pipelineFullName, "")
-                .replaceAll("//", "/")));
         event.setSubjectId(run.getId());
         event.setSource(URI.create(run.getUrl()));
         event.setSubjectPipelineName(pipelineFullName);
@@ -72,10 +68,6 @@ public class BuildCDEvent {
 
         PipelineRunFinishedCDEvent event = new PipelineRunFinishedCDEvent();
 
-        event.setSubjectSource(URI.create(run.getParent()
-                .getUrl()
-                .replaceAll(pipelineFullName, "")
-                .replaceAll("//", "/")));
         event.setSubjectId(run.getId());
         event.setSource(URI.create(run.getUrl()));
         event.setSubjectPipelineName(pipelineFullName);
@@ -93,7 +85,6 @@ public class BuildCDEvent {
         LOGGER.log(Level.INFO, "Building PipelineRunQueued model for " + pipelineFullName);
 
         PipelineRunQueuedCDEvent event = new PipelineRunQueuedCDEvent();
-        event.setSubjectSource(URI.create(item.task.getUrl()));
         event.setSubjectId(String.valueOf(item.getId()));
         event.setSource(URI.create(item.task.getUrl()));
         event.setSubjectPipelineName(pipelineFullName);
@@ -110,7 +101,6 @@ public class BuildCDEvent {
 
         TaskRunStartedCDEvent event = new TaskRunStartedCDEvent();
 
-        event.setSubjectSource(URI.create(run.getParent().getUrl().replaceAll(displayName, "").replaceAll("//", "/")));
         event.setSource(URI.create(run.getUrl()));
         event.setSubjectId(run.getId());
         event.setSubjectTaskName(displayName);
@@ -140,7 +130,6 @@ public class BuildCDEvent {
         LOGGER.info("Building TaskRunFinished model for " + displayName);
 
         TaskRunFinishedCDEvent event = new TaskRunFinishedCDEvent();
-        event.setSubjectSource(URI.create(run.getParent().getUrl().replaceAll(displayName, "").replaceAll("//", "/")));
         event.setSource(URI.create(run.getUrl()));
         event.setSubjectId(run.getId());
         event.setSubjectTaskName(displayName);

--- a/src/main/java/io/jenkins/plugins/cdevents/CDEventsGlobalConfig.java
+++ b/src/main/java/io/jenkins/plugins/cdevents/CDEventsGlobalConfig.java
@@ -113,9 +113,9 @@ public class CDEventsGlobalConfig extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
-    public FormValidation doCheckKinesisEndpoint(@QueryParameter("kinesisEndpoint") String kinesisEndpoint, @QueryParameter("kinesisRegion") String kinesisRegion) {
+    public FormValidation doCheckKinesisEndpoint(@QueryParameter("kinesisEndpoint") String kinesisEndpoint, @QueryParameter("kinesisRegion") String kinesisRegion) throws FormValidation {
         if (!isNullOrEmpty(kinesisEndpoint) && isNullOrEmpty(kinesisRegion)) {
-            FormValidation.error("Kinesis requires a defined region for a custom endpoint");
+            throw FormValidation.error("Kinesis requires a defined region for a custom endpoint");
         }
         return FormValidation.ok();
     }

--- a/src/main/java/io/jenkins/plugins/cdevents/sinks/KinesisSink.java
+++ b/src/main/java/io/jenkins/plugins/cdevents/sinks/KinesisSink.java
@@ -22,10 +22,10 @@ import java.util.logging.Logger;
 public class KinesisSink extends CDEventsSink {
 
     public static final Logger LOGGER = Logger.getLogger(KinesisSink.class.getName());
-    public volatile static AmazonKinesis kinesis;
-    public volatile static String streamName;
-    public volatile static String region;
-    public volatile static String endpoint;
+    private volatile static AmazonKinesis kinesis;
+    private volatile static String streamName;
+    private volatile static String region;
+    private volatile static String endpoint;
 
     public KinesisSink() {
         if (Jenkins.get().getPlugin("aws-java-sdk") == null

--- a/src/main/java/io/jenkins/plugins/cdevents/util/OutcomeMapper.java
+++ b/src/main/java/io/jenkins/plugins/cdevents/util/OutcomeMapper.java
@@ -18,20 +18,20 @@ public class OutcomeMapper {
         switch (result.toString().toUpperCase()) {
             case "SUCCESS":
             case "UNSTABLE":
-                return CDEventConstants.Outcome.OutcomeSuccess;
+                return CDEventConstants.Outcome.SUCCESS;
             case "NOT_BUILT":
             case "ABORTED":
-                return CDEventConstants.Outcome.OutcomeFailure;
+                return CDEventConstants.Outcome.FAILURE;
             default: // Jenkins status FAILURE and all others
-                return CDEventConstants.Outcome.OutcomeError;
+                return CDEventConstants.Outcome.ERROR;
         }
     }
 
     public static CDEventConstants.Outcome mapResultToOutcome(ErrorAction error) {
         if (error != null) {
-            return CDEventConstants.Outcome.OutcomeError;
+            return CDEventConstants.Outcome.ERROR;
         } else {
-            return CDEventConstants.Outcome.OutcomeSuccess;
+            return CDEventConstants.Outcome.SUCCESS;
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/cdevents/BuildCDEvent.java
+++ b/src/test/java/io/jenkins/plugins/cdevents/BuildCDEvent.java
@@ -54,7 +54,6 @@ class BuildCDEventTest {
         try (MockedStatic<ModelBuilder> modelBuilder = getMockedModelBuilder()) {
             modelBuilder.when(() -> ModelBuilder.buildJobModel(job, run, taskListener)).thenReturn(new JobModel());
             when(run.getParent().getFullDisplayName()).thenReturn("TestJob1");
-            when(run.getParent().getUrl()).thenReturn("http://localhost/job/1");
             when(run.getUrl()).thenReturn("http://localhost/job/1/stage/1");
             when(run.getId()).thenReturn("1");
 

--- a/src/test/java/io/jenkins/plugins/cdevents/sinks/KinesisSinkTest.java
+++ b/src/test/java/io/jenkins/plugins/cdevents/sinks/KinesisSinkTest.java
@@ -7,8 +7,8 @@ package io.jenkins.plugins.cdevents.sinks;
 
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
-import dev.cdevents.CDEventTypes;
-import dev.cdevents.constants.CDEventConstants;
+import dev.cdevents.CDEvents;
+import dev.cdevents.events.PipelineRunStartedCDEvent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Plugin;
 import io.cloudevents.CloudEvent;
@@ -30,22 +30,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-@SuppressFBWarnings(value = {"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"},
+@SuppressFBWarnings(value = {"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+        "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"},
         justification = "Tests are just checking that exceptions are not thrown. Feel free to add more robust tests")
 @ExtendWith(MockitoExtension.class)
 class KinesisSinkTest {
 
-    private final CloudEvent cloudEvent = CDEventTypes.createPipelineRunStartedEvent(
-            CDEventConstants.CDEventTypes.PipelineRunStartedEvent.getEventType(),
-            "1",
-            URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"),
-            "unittest",
-            URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"),
-            "{\"userId\":null,\"userName\":null,\"name\":\"PipelineTest\",\"displayName\":" +
-                    "\"PipelineTest\",\"url\":\"job/PipelineTest/\",\"build\":{\"fullUrl\":\"http://local" +
-                    "host:8080/jenkins/job/PipelineTest/16/\",\"number\":16,\"queueId\":8,\"duration\":0," +
-                    "\"status\":null,\"url\":\"job/PipelineTest/16/\",\"displayName\":null,\"parameters\"" +
-                    ":null,\"scmState\":{\"url\":null,\"branch\":null,\"commit\":null}}}");
+    private CloudEvent cloudEvent;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private AmazonKinesis mockKinesisClient;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -58,14 +49,33 @@ class KinesisSinkTest {
     @BeforeEach
     void setup() {
         reset(mockClientBuilder, mockKinesisClient, mockJenkins, mockGlobalConfig);
+
+        /*when creating new object of any CDEvent type, the event will be initialized with
+        context.id, context.type, context.version, context.timestamp and subject.type */
+        PipelineRunStartedCDEvent event = new PipelineRunStartedCDEvent();
+
+        /* set the required context fields to the PipelineRunStartedCDEvent */
+        event.setSource(URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"));
+
+        /* set the required subject fields to the PipelineRunStartedCDEvent */
+        event.setSubjectId("1");
+        event.setSubjectSource(URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"));
+        event.setSubjectUrl(URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"));
+        event.setSubjectPipelineName("unittest");
+
+        event.setCustomDataContentType("application/json");
+        event.setCustomData("{\"userId\":null,\"userName\":null,\"name\":\"PipelineTest\",\"displayName\":" +
+                "\"PipelineTest\",\"url\":\"job/PipelineTest/\",\"build\":{\"fullUrl\":\"http://local" + "host:8080" + "/jenkins/job/PipelineTest/16/\",\"number\":16,\"queueId\":8,\"duration\":0," + "\"status\":null," + "\"url\":\"job/PipelineTest/16/\",\"displayName\":null,\"parameters\"" + ":null,\"scmState\":{\"url" + "\":null,\"branch\":null,\"commit\":null}}}");
+
+        /* Create a CloudEvent from a PipelineRunStartedCDEvent */
+        cloudEvent = CDEvents.cdEventAsCloudEvent(event);
     }
 
     private MockedStatic<CDEventsGlobalConfig> getMockCDEventsGlobalConfigStatic() {
         return mockStatic(CDEventsGlobalConfig.class, Answers.RETURNS_DEEP_STUBS);
     }
 
-    private void configureMockCDEventsGlobalConfigStatic(
-            MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic) {
+    private void configureMockCDEventsGlobalConfigStatic(MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic) {
         mockCDEventsGlobalConfigStatic.when(CDEventsGlobalConfig::get).thenReturn(mockGlobalConfig);
         when(mockGlobalConfig.getKinesisStreamName()).thenReturn("hello");
     }
@@ -92,9 +102,7 @@ class KinesisSinkTest {
 
     @Test
     void sinkTest() {
-        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic();
-             MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic();
-             MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic(); MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
             configureMockJenkinsStatic(mockJenkinsStatic);
             configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
             configureMockClientBuilderStatic(mockClientBuilderStatic);
@@ -118,8 +126,7 @@ class KinesisSinkTest {
 
     @Test
     void constructorFailsNoStreamName() {
-        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic();
-             MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic()) {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic()) {
             configureMockJenkinsStatic(mockJenkinsStatic);
             configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
 

--- a/src/test/java/io/jenkins/plugins/cdevents/sinks/SyslogSinkTest.java
+++ b/src/test/java/io/jenkins/plugins/cdevents/sinks/SyslogSinkTest.java
@@ -5,8 +5,8 @@
 
 package io.jenkins.plugins.cdevents.sinks;
 
-import dev.cdevents.CDEventTypes;
-import dev.cdevents.constants.CDEventConstants;
+import dev.cdevents.CDEvents;
+import dev.cdevents.events.PipelineRunStartedCDEvent;
 import io.cloudevents.CloudEvent;
 import org.junit.jupiter.api.Test;
 
@@ -16,21 +16,30 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class SyslogSinkTest {
 
-    private final CloudEvent cloudEvent = CDEventTypes.createPipelineRunStartedEvent(
-            CDEventConstants.CDEventTypes.PipelineRunStartedEvent.getEventType(),
-            "1",
-            URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"),
-            "unittest",
-            URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"),
-            "{\"userId\":null,\"userName\":null,\"name\":\"PipelineTest\",\"displayName\":" +
-                    "\"PipelineTest\",\"url\":\"job/PipelineTest/\",\"build\":{\"fullUrl\":\"http://local" +
-                    "host:8080/jenkins/job/PipelineTest/16/\",\"number\":16,\"queueId\":8,\"duration\":0," +
-                    "\"status\":null,\"url\":\"job/PipelineTest/16/\",\"displayName\":null,\"parameters\"" +
-                    ":null,\"scmState\":{\"url\":null,\"branch\":null,\"commit\":null}}}");
-
     @Test
     void sendCloudEvent_works() {
         SyslogSink syslogSink = new SyslogSink();
+
+        /*when creating new object of any CDEvent type, the event will be initialized with
+        context.id, context.type, context.version, context.timestamp and subject.type */
+        PipelineRunStartedCDEvent event = new PipelineRunStartedCDEvent();
+
+        /* set the required context fields to the PipelineRunStartedCDEvent */
+        event.setSource(URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"));
+
+        /* set the required subject fields to the PipelineRunStartedCDEvent */
+        event.setSubjectId("1");
+        event.setSubjectSource(URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"));
+        event.setSubjectUrl(URI.create("http://localhost:8080/jenkins/job/PipelineTest/1/"));
+        event.setSubjectPipelineName("unittest");
+
+        event.setCustomDataContentType("application/json");
+        event.setCustomData("{\"userId\":null,\"userName\":null,\"name\":\"PipelineTest\",\"displayName\":" +
+                "\"PipelineTest\",\"url\":\"job/PipelineTest/\",\"build\":{\"fullUrl\":\"http://local" + "host:8080" + "/jenkins/job/PipelineTest/16/\",\"number\":16,\"queueId\":8,\"duration\":0," + "\"status\":null," + "\"url\":\"job/PipelineTest/16/\",\"displayName\":null,\"parameters\"" + ":null,\"scmState\":{\"url" + "\":null,\"branch\":null,\"commit\":null}}}");
+
+        /* Create a CloudEvent from a PipelineRunStartedCDEvent */
+        CloudEvent cloudEvent = CDEvents.cdEventAsCloudEvent(event);
+
         assertDoesNotThrow(() -> syslogSink.sendCloudEvent(cloudEvent));
     }
 }


### PR DESCRIPTION
Closes #12

This commit increments our cdevents-sdk-java dependency from v0.1.0-draft6 to version 0.1.2, which corresponds to [CDEvents spec v0.1.2](https://github.com/cdevents/spec/blob/v0.1.2/spec.md). We encourage users to review the [CDEvents spec repository](https://github.com/cdevents/spec/compare/v0.1.0...v0.1.2) to determine if these changes will have a material impact on your use case.

We have also incremented the optional dependency on the AWS SDK plugin for our Kinesis users. Finally, we are targeting a minimum Jenkins release version of 2.401.3.