### PR TITLE
Replace fat `aws-java-sdk` with fine-grained `aws-java-sdk-kinesis`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
             <version>1.12.447-382.vda_68e2007233</version>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
## What

This replaces the fat plugin `aws-java-sdk` with the fine-grained plugin `aws-java-sdk-kinesis` that is used from this plugin (judging from imports).

## Why

The `aws-java-sdk` plugin is very heavyweight, using the modular plugin instead allows to reduce the overall size of the installation without removing any feature.

## How

I don't know anything about this plugin, only that it could avoid pulling this big dependency ;)

### Changes details

- Detail one
- Detail two
  ...

## Missed anything?

- [ ] Explained the purpose of this PR.
- [ ] Self reviewed the PR.
- [ ] Added or updated test cases.
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Updated documentation (if applicable).
- [ ] Attached screenshots (if applicable).
