### PR TITLE
Corrected null check on KinesisSink/KinesisStreamName and added a test case

### DIFF
--- a/src/main/java/io/jenkins/plugins/cdevents/sinks/KinesisSink.java
+++ b/src/main/java/io/jenkins/plugins/cdevents/sinks/KinesisSink.java
@@ -37,7 +37,7 @@ public class KinesisSink extends CDEventsSink {
         }
 
         if (CDEventsGlobalConfig.get().getKinesisStreamName() == null
-                && CDEventsGlobalConfig.get().getKinesisStreamName().trim().isEmpty()) {
+                || CDEventsGlobalConfig.get().getKinesisStreamName().trim().isEmpty()) {
             throw new NullPointerException("Kinesis stream name cannot be blank");
         }
 

--- a/src/test/java/io/jenkins/plugins/cdevents/sinks/KinesisSinkTest.java
+++ b/src/test/java/io/jenkins/plugins/cdevents/sinks/KinesisSinkTest.java
@@ -137,4 +137,16 @@ class KinesisSinkTest {
         }
     }
 
+    @Test
+    void constructorFailsEmptyStreamName() {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic()){
+            configureMockJenkinsStatic(mockJenkinsStatic);
+            configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
+
+            reset(mockGlobalConfig);
+            when(mockGlobalConfig.getKinesisStreamName()).thenReturn("");
+
+            assertThrows(NullPointerException.class, () -> new KinesisSink());
+        }
+    }
 }


### PR DESCRIPTION
## What

What does the PR do?
This PR corrects the null check when KinesisStreamName is an empty string. 

## Why

Why this PR is needed?
This corrects the bug raised in issue #19 
## How

How is it doing what it does?
Fixed the null check to behave correctly. 

### Changes details

- Corrected the null check on KinesisSink/KinesisStreamName
- Added a test case to check the behaviour given an empty string as the stream name. 

## Missed anything?

- [x] Explained the purpose of this PR.
- [x] Self reviewed the PR.
- [x] Added or updated test cases.
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Updated documentation (if applicable).
- [ ] Attached screenshots (if applicable).
