### PR TITLE
added jacoco to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,26 @@
                     <useUnlimitedThreads>true</useUnlimitedThreads>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This pull request includes a change to the pom.xml file. The change adds the JaCoCo Maven plugin to the project, which is a tool used for measuring code coverage. The plugin is configured to prepare an agent and generate a report during the test phase of the Maven build lifecycle.

Why
To address issue #17 in public repo

How
How is it doing what it does?
It is generating a HTML report

fixes #17 