### PR TITLE
Added 4 Required Unit Test Cases

### DIFF
--- a/src/test/java/io/jenkins/plugins/cdevents/sinks/KinesisSinkTest.java
+++ b/src/test/java/io/jenkins/plugins/cdevents/sinks/KinesisSinkTest.java
@@ -5,6 +5,8 @@
 
 package io.jenkins.plugins.cdevents.sinks;
 
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
 import dev.cdevents.CDEvents;
@@ -147,6 +149,91 @@ class KinesisSinkTest {
             when(mockGlobalConfig.getKinesisStreamName()).thenReturn("");
 
             assertThrows(NullPointerException.class, () -> new KinesisSink());
+        }
+    }
+
+    @Test
+    void kinesisClientBuiltWithoutIamRole() {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic(); MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
+            configureMockJenkinsStatic(mockJenkinsStatic);
+            configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
+            configureMockClientBuilderStatic(mockClientBuilderStatic);
+
+            reset(mockGlobalConfig);
+            when(mockGlobalConfig.getIamRole()).thenReturn("");
+
+            KinesisSink sink = new KinesisSink();
+            assertDoesNotThrow(() -> sink.sendCloudEvent(cloudEvent));
+
+            verify(mockClientBuilder, never()).withCredentials(any(STSAssumeRoleSessionCredentialsProvider.class));
+        }
+    }
+
+    @Test
+    void kinesisClientBuiltWithRegion() {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic(); MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
+            configureMockJenkinsStatic(mockJenkinsStatic);
+            configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
+            configureMockClientBuilderStatic(mockClientBuilderStatic);
+
+            reset(mockGlobalConfig);
+            when(mockGlobalConfig.getKinesisRegion()).thenReturn("us-west-2");
+
+            KinesisSink sink = new KinesisSink();
+            assertDoesNotThrow(() -> sink.sendCloudEvent(cloudEvent));
+
+            verify(mockClientBuilder).withRegion("us-west-2");
+        }
+    }
+
+    @Test
+    void kinesisClientBuiltWithoutRegion() {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic(); MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
+            configureMockJenkinsStatic(mockJenkinsStatic);
+            configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
+            configureMockClientBuilderStatic(mockClientBuilderStatic);
+
+            reset(mockGlobalConfig);
+            when(mockGlobalConfig.getKinesisRegion()).thenReturn("");
+
+            KinesisSink sink = new KinesisSink();
+            assertDoesNotThrow(() -> sink.sendCloudEvent(cloudEvent));
+
+            verify(mockClientBuilder, never()).withRegion(anyString());
+        }
+    }
+
+    @Test
+    void kinesisClientBuiltWithEndpoint() {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic(); MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
+            configureMockJenkinsStatic(mockJenkinsStatic);
+            configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
+            configureMockClientBuilderStatic(mockClientBuilderStatic);
+
+            reset(mockGlobalConfig);
+            when(mockGlobalConfig.getKinesisEndpoint()).thenReturn("http://localhost:4566");
+
+            KinesisSink sink = new KinesisSink();
+            assertDoesNotThrow(() -> sink.sendCloudEvent(cloudEvent));
+
+            verify(mockClientBuilder).withEndpointConfiguration(any(AwsClientBuilder.EndpointConfiguration.class));
+        }
+    }
+
+    @Test
+    void kinesisClientBuiltWithoutEndpoint() {
+        try (MockedStatic<Jenkins> mockJenkinsStatic = getMockJenkinsStatic(); MockedStatic<CDEventsGlobalConfig> mockCDEventsGlobalConfigStatic = getMockCDEventsGlobalConfigStatic(); MockedStatic<AmazonKinesisClientBuilder> mockClientBuilderStatic = getMockClientBuilderStatic()) {
+            configureMockJenkinsStatic(mockJenkinsStatic);
+            configureMockCDEventsGlobalConfigStatic(mockCDEventsGlobalConfigStatic);
+            configureMockClientBuilderStatic(mockClientBuilderStatic);
+
+            reset(mockGlobalConfig);
+            when(mockGlobalConfig.getKinesisEndpoint()).thenReturn("");
+
+            KinesisSink sink = new KinesisSink();
+            assertDoesNotThrow(() -> sink.sendCloudEvent(cloudEvent));
+
+            verify(mockClientBuilder, never()).withEndpointConfiguration(any(AwsClientBuilder.EndpointConfiguration.class));
         }
     }
 }


### PR DESCRIPTION
## What

This PR adds new test cases to ensure the robustness and reliability of the KinesisSink class. 
This fixes the [#18](https://github.com/jenkinsci/cdevents-plugin/issues/18)

## Why

This PR is needed to ensure that the KinesisSink class:

  - Handles various configurations correctly, including cases where some configurations are missing or blank.
  - Has comprehensive test coverage to catch potential issues early and ensure the stability of the codebase.

## How

By incorporating the following changes:

### Changes details

**KinesisSink Class Enhancements:**

Added checks for null or empty stream names.
Improved client-building logic to handle optional iamRole, region, and endpoint.

**Unit Tests:**

Added comprehensive test cases to cover various configuration scenarios using Mockito for dependency mocking.
  
1. **Test iamRole Not Provided:** Verifies that the Kinesis client is built without iamRole.
2. **Test Kinesis Stream Name Provided:** Ensures that the Kinesis client is built with the provided stream name.
3. **Test Kinesis Stream Name Is Blank:** Check that a NullPointerException is thrown when the Kinesis stream name is blank.
4. **Test Kinesis Region Is Blank:** Verifies that the Kinesis client is built without specifying a region if the region is blank.
5. **Test Kinesis Endpoint Is Blank:** Ensures that the Kinesis client is built without specifying an endpoint if the endpoint is blank.

## Missed anything?

- [X] Explained the purpose of this PR.
- [X] Self-reviewed the PR.
- [X] Added or updated test cases.
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [X] Updated documentation (if applicable).
- [ ] Attached screenshots (if applicable).
